### PR TITLE
Fix rerun call for current Streamlit versions

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -178,12 +178,12 @@ Once labeled, the email moves to the **labeled dataset** above.
                         ss["labeled"].append({"title": item["title"], "body": item["body"], "label": "spam"})
                         ss["incoming"].pop(i)
                         st.success("Labeled as spam and moved to dataset.")
-                        st.experimental_rerun()
+                        st.rerun()
                     if col_btn2.button("Mark as safe", key=f"mark_safe_{i}"):
                         ss["labeled"].append({"title": item["title"], "body": item["body"], "label": "safe"})
                         ss["incoming"].pop(i)
                         st.success("Labeled as safe and moved to dataset.")
-                        st.experimental_rerun()
+                        st.rerun()
 
 with tab_train:
     st.subheader("2) Train — make the model learn")


### PR DESCRIPTION
## Summary
- replace deprecated `st.experimental_rerun` calls with `st.rerun` to align with the current Streamlit API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e253d977448321a5c3cf86644519ac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced experimental rerun calls with the stable rerun API when marking inbox items as spam or safe.
  * Improves stability, reduces deprecation warnings, and keeps behavior unchanged—the app still refreshes immediately after labeling.
  * Enhances compatibility with current and future Streamlit versions.
  * No user-facing feature changes; workflows and results remain the same, with a more reliable refresh experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->