### PR TITLE
Fix StageMeta forward reference in streamlit app

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import html
 from dataclasses import dataclass


### PR DESCRIPTION
## Summary
- enable postponed evaluation of annotations so StageMeta can be used in type hints before its definition

## Testing
- python -m compileall streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68e3774711848321acae4d16fd66aa62