### PR TITLE
Replace deprecated Streamlit query param API usage

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -301,7 +301,8 @@ def set_active_stage(stage_key: str):
     if stage_key not in STAGE_BY_KEY:
         return
     st.session_state["active_stage"] = stage_key
-    st.experimental_set_query_params(stage=stage_key)
+    if st.query_params.get_all("stage") != [stage_key]:
+        st.query_params["stage"] = stage_key
 
 
 def render_stage_navigation_controls(active_stage: str):
@@ -1234,7 +1235,8 @@ if requested_stage in STAGE_BY_KEY:
     if requested_stage != ss["active_stage"]:
         ss["active_stage"] = requested_stage
 else:
-    st.experimental_set_query_params(stage=ss["active_stage"])
+    if st.query_params.get_all("stage") != [ss["active_stage"]]:
+        st.query_params["stage"] = ss["active_stage"]
 ss.setdefault("nerd_mode", False)
 ss.setdefault("autonomy", AUTONOMY_LEVELS[0])
 ss.setdefault("threshold", 0.6)


### PR DESCRIPTION
## Summary
- update query parameter handling to use the supported `st.query_params` API and avoid mixing experimental calls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e387d9e5e48321bfc39af261142024