### PR TITLE
Fix training summary rendering on model tab

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1009,13 +1009,10 @@ def make_after_training_story(train_labels: list[str], test_labels: list[str]) -
     ct_test = _counts(test_labels)
     lines: list[str] = []
     lines.append(
-        "**Training complete.** The model learned from **{n_train}** emails "
-        "({ct_train['spam']} spam / {ct_train['safe']} safe) and will be checked on "
-        "**{n_test}** unseen emails ({ct_test['spam']} spam / {ct_test['safe']} safe).".format(
-            n_train=n_train,
-            ct_train=ct_train,
-            n_test=n_test,
-            ct_test=ct_test,
+        (
+            f"**Training complete.** The model learned from **{n_train}** emails "
+            f"({ct_train['spam']} spam / {ct_train['safe']} safe) and will be checked on "
+            f"**{n_test}** unseen emails ({ct_test['spam']} spam / {ct_test['safe']} safe)."
         )
     )
     lines.append(


### PR DESCRIPTION
## Summary
- replace the broken string formatting used in the training completion message
- ensure the spam and safe counts are interpolated correctly by using f-strings

## Testing
- python -m compileall streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68e393cf2e888321804b8867875d8d6c