### PR TITLE
Fix Streamlit high autonomy toggle state initialization

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2329,14 +2329,14 @@ def render_classify_stage():
     )
 
     st.markdown("### Autonomy")
-    ss["use_high_autonomy"] = ss.get("autonomy", AUTONOMY_LEVELS[0]).startswith("High")
+    default_high_autonomy = ss.get("autonomy", AUTONOMY_LEVELS[0]).startswith("High")
     col_auto1, col_auto2 = st.columns([1, 3])
     with col_auto1:
-        ss["use_high_autonomy"] = st.toggle(
-            "High autonomy (auto-move emails)", value=ss["use_high_autonomy"], key="use_high_autonomy"
+        use_high_autonomy = st.toggle(
+            "High autonomy (auto-move emails)", value=default_high_autonomy, key="use_high_autonomy"
         )
     with col_auto2:
-        if ss["use_high_autonomy"]:
+        if use_high_autonomy:
             ss["autonomy"] = AUTONOMY_LEVELS[1]
             st.success("High autonomy ON — the system will **move** emails to Spam or Inbox automatically.")
         else:


### PR DESCRIPTION
## Summary
- avoid reassigning `st.session_state` for the high autonomy toggle before the widget renders
- use the toggle's return value to drive autonomy messaging without triggering Streamlit state errors

## Testing
- not run (Streamlit UI fix)


------
https://chatgpt.com/codex/tasks/task_e_68e3b214d4148321b00c9a5ccfc896fa