### PR TITLE
Fix adaptiveness toggle session state clash

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2489,10 +2489,9 @@ def render_classify_stage():
     use_adaptiveness = st.toggle(
         "Enable adaptiveness (learn from feedback)", value=default_adaptiveness, key="use_adaptiveness"
     )
-    ss["use_adaptiveness"] = use_adaptiveness
     ss["adaptive"] = use_adaptiveness
 
-    if ss["use_adaptiveness"] and ss.get("use_batch_results"):
+    if use_adaptiveness and ss.get("use_batch_results"):
         st.markdown("#### Review and give feedback")
         for i, row in enumerate(ss["use_batch_results"]):
             with st.container(border=True):


### PR DESCRIPTION
## Summary
- stop manually overwriting `st.session_state["use_adaptiveness"]` after the toggle is created
- reuse the toggle return value when rendering adaptive feedback controls to avoid the StreamlitAPIException

## Testing
- python -m compileall streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68e3b4ef392483218515edab5322f9a8