### PR TITLE
Fix nerd mode toggle state handling

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2462,8 +2462,12 @@ def render_classify_stage():
         )
 
         with st.expander("🔬 Nerd Mode — details for this batch", expanded=False):
-            ss["nerd_mode_use"] = st.toggle("Enable Nerd Mode for Use", value=ss["nerd_mode_use"], key="nerd_mode_use")
-            if ss["nerd_mode_use"]:
+            nerd_mode_enabled = st.toggle(
+                "Enable Nerd Mode for Use",
+                value=ss.get("nerd_mode_use", False),
+                key="nerd_mode_use",
+            )
+            if nerd_mode_enabled:
                 col_nm1, col_nm2 = st.columns([2, 1])
                 with col_nm1:
                     st.markdown("**Raw probabilities (per email)**")


### PR DESCRIPTION
## Summary
- avoid reassigning Streamlit session state for the use-tab nerd mode toggle after widget creation
- read the stored state through st.toggle with a safe default and gate the details panel off the returned value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3b84ec2588321ab62a15130a305c0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a histogram visualization of spam probability (p_spam) when Nerd Mode is enabled in the Use stage, offering quick insight into per-batch distributions.
  * Preserved detailed per-batch views (raw probabilities and batch metrics) under Nerd Mode for deeper analysis.
  * Improved consistency of the Nerd Mode toggle behavior, ensuring details and visualizations display reliably when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->