### PR TITLE
Fix Streamlit high autonomy toggle state update

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2556,8 +2556,6 @@ def render_classify_stage():
             st.success("High autonomy ON — the system will **move** emails to Spam or Inbox automatically.")
         else:
             ss["autonomy"] = AUTONOMY_LEVELS[0]
-    ss["use_high_autonomy"] = use_high_autonomy
-
     if not ss.get("model"):
         st.warning("Train a model first in the **Train** tab.")
         st.stop()


### PR DESCRIPTION
## Summary
- stop manually overwriting `st.session_state.use_high_autonomy` after the toggle widget renders to avoid Streamlit API errors

## Testing
- python -m py_compile streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c1dab6688321ae2dc9f3090134bf