### PR TITLE
Add start button to welcome flow column

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2438,6 +2438,14 @@ def render_intro_stage():
             st.markdown("### Ready to make a machine learn?")
             st.write("Use the stage controls below or the sidebar to move through the build at your pace.")
         with flow_col:
+            if next_stage_key:
+                st.button(
+                    "🚀 Start your machine",
+                    key="flow_start_machine",
+                    type="primary",
+                    on_click=set_active_stage,
+                    args=(next_stage_key,),
+                )
             st.markdown(
                 "- Each step builds on the previous one, and you can always hop back.\n"
                 "- Nerd Mode reveals deeper technical layers when you need them."


### PR DESCRIPTION
## Summary
- add a primary "Start your machine" button above the quick tips on the welcome stage
- reuse the stage progression handler so the new button advances visitors to the next stage

## Testing
- streamlit run streamlit_app.py --server.headless true --server.port 8501

------
https://chatgpt.com/codex/tasks/task_e_68e3dd26f2648321af9f0b8250dd1d85