### PR TITLE
Wrap EU AI Act quote in welcome span

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2379,10 +2379,15 @@ def render_intro_stage():
             )
             st.markdown("#### The EU AI Act definition of AI system")
             st.markdown(
-                "“a machine-based system that is designed to operate with varying levels of autonomy and that may exhibit "
-                "adaptiveness after deployment, and that, for explicit or implicit objectives, infers, from the input it "
-                "receives, how to generate outputs such as predictions, content, recommendations, or decisions that can "
-                "influence physical or virtual environments.”"
+                """
+                <span class="ai-quote-box_source">
+                “a machine-based system that is designed to operate with varying levels of autonomy and that may exhibit
+                adaptiveness after deployment, and that, for explicit or implicit objectives, infers, from the input it
+                receives, how to generate outputs such as predictions, content, recommendations, or decisions that can
+                influence physical or virtual environments.”
+                </span>
+                """,
+                unsafe_allow_html=True,
             )
             if next_stage_key:
                 st.button(


### PR DESCRIPTION
## Summary
- wrap the EU AI Act definition on the welcome stage in a span with the `ai-quote-box_source` class so it can be styled consistently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4db92848c83219ecd177998f59c83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the visual presentation of the EU AI Act definition using rich HTML formatting for clearer, more readable quotes.
  * Applied the improved formatting consistently across the intro sections where the definition appears.
  * No changes to app behavior or data handling; this update strictly refines on-screen text styling for a more polished user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->