### PR TITLE
Wrap EU AI Act definition in intro quote callout

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2470,16 +2470,11 @@ def render_intro_stage():
                 "- how autonomy levels affect you as a user, and how optional adaptiveness feeds your feedback back into training."
             )
             st.markdown("#### The EU AI Act definition of AI system")
-            st.markdown(
-                """
-                <span class="ai-quote-box_source">
-                “a machine-based system that is designed to operate with varying levels of autonomy and that may exhibit
-                adaptiveness after deployment, and that, for explicit or implicit objectives, infers, from the input it
-                receives, how to generate outputs such as predictions, content, recommendations, or decisions that can
-                influence physical or virtual environments.”
-                </span>
-                """,
-                unsafe_allow_html=True,
+            render_eu_ai_quote(
+                "“a machine-based system that is designed to operate with varying levels of autonomy and that may exhibit "
+                "adaptiveness after deployment, and that, for explicit or implicit objectives, infers, from the input it "
+                "receives, how to generate outputs such as predictions, content, recommendations, or decisions that can "
+                "influence physical or virtual environments.”"
             )
             if next_stage_key:
                 st.button(


### PR DESCRIPTION
## Summary
- replace the intro page's raw HTML block with the reusable EU AI quote callout helper
- keep the EU AI Act definition content while matching the quote styling used elsewhere

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4e2d9fc208321af9cd06ef020d921