### PR TITLE
Fix start button rendering on intro hero

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2603,19 +2603,21 @@ def render_intro_stage():
                         both—showing how everyday AI works in practice.
                     </p>
                 </div>
-                
-               if next_stage_key:
-                st.button(
-                    "🚀 Start your machine",
-                    key="flow_start_machine",
-                    type="primary",
-                    on_click=set_active_stage,
-                    args=(next_stage_key,),
-                )
             </div>
-       
             """
             st.markdown(hero_info_html, unsafe_allow_html=True)
+
+            if next_stage_key:
+                _, button_col = st.columns([1, 1])
+                with button_col:
+                    st.button(
+                        "🚀 Start your machine",
+                        key="flow_start_machine",
+                        type="primary",
+                        on_click=set_active_stage,
+                        args=(next_stage_key,),
+                        use_container_width=True,
+                    )
 
     with section_surface():
         block2_left, block2_right = st.columns([3, 2], gap="large")


### PR DESCRIPTION
## Summary
- ensure the intro hero renders its informational cards via HTML and keeps the start button in Python logic so it displays correctly
- position the "Start your machine" call-to-action inside the right column using Streamlit columns and container width

## Testing
- python -m compileall streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68e4ff8b95b48321a58a3bb569b72b57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Relocated “Start your machine” to a dedicated button below the hero for improved visibility and clarity.
  - Introduced a balanced two-column layout under the hero to enhance spacing and responsiveness.
  - Button now uses the available width for easier tapping and readability.
  - The action button appears only when the next step is available, reducing visual clutter and guiding users through the flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->