### PR TITLE
Fix indentation error in intro stage layout

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2906,13 +2906,13 @@ def render_intro_stage():
                         use_container_width=True,
                     )
     with section_surface():
-            st.markdown(
-                """
-                <div>
-                    <h4>Your AI system lifecycle at a glance</h4>
-                    <p>These are the core stages you will navigate. They flow into one another — it’s a continuous loop you can revisit.</p>
-                    <div class="lifecycle-flow">
-                        <div class="lifecycle-step">
+        st.markdown(
+            """
+            <div>
+                <h4>Your AI system lifecycle at a glance</h4>
+                <p>These are the core stages you will navigate. They flow into one another — it’s a continuous loop you can revisit.</p>
+                <div class="lifecycle-flow">
+                    <div class="lifecycle-step">
                             <span class="lifecycle-icon">📊</span>
                             <span class="lifecycle-label">Prepare Data</span>
                         </div>


### PR DESCRIPTION
## Summary
- correct the intro stage lifecycle layout block indentation so the script compiles again

## Testing
- python -m compileall streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68e50b582ff0832197cf47197e1608a8