### PR TITLE
Fix intro stage button indentation error

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2896,15 +2896,14 @@ def render_intro_stage():
 
             if next_stage_key:
                 _, button_col = st.columns([1, 1])
-                with button_col:
-                    st.button(
-                        "🚀 Start your machine",
-                        key="flow_start_machine",
-                        type="primary",
-                        on_click=set_active_stage,
-                        args=(next_stage_key,),
-                        use_container_width=True,
-                    )
+                button_col.button(
+                    "🚀 Start your machine",
+                    key="flow_start_machine",
+                    type="primary",
+                    on_click=set_active_stage,
+                    args=(next_stage_key,),
+                    use_container_width=True,
+                )
     with section_surface():
         st.markdown(
             """


### PR DESCRIPTION
## Summary
- resolve the indentation issue around the intro stage start button by calling the column's button method directly
- ensure the Streamlit app compiles without indentation errors

## Testing
- python -m py_compile streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68e50c5d8754832194e12048727b24dc