### PR TITLE
Fix duplicate Streamlit button keys on welcome page

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2898,7 +2898,7 @@ def render_intro_stage():
                 _, button_col = st.columns([1, 1])
                 button_col.button(
                     "🚀 Start your machine",
-                    key="flow_start_machine",
+                    key="flow_start_machine_hero",
                     type="primary",
                     on_click=set_active_stage,
                     args=(next_stage_key,),
@@ -2999,7 +2999,7 @@ def render_intro_stage():
             if next_stage_key:
                 st.button(
                     "🚀 Start your machine",
-                    key="flow_start_machine",
+                    key="flow_start_machine_ready",
                     type="primary",
                     on_click=set_active_stage,
                     args=(next_stage_key,),


### PR DESCRIPTION
## Summary
- assign distinct Streamlit keys to the welcome page "Start your machine" buttons to avoid duplicate key errors

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e510bf3ec88321ac3245363041e74d