### PR TITLE
Fix undefined outcomes_html reference

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3010,7 +3010,7 @@ def render_overview_stage():
                 </div>
             </div>
             """
-            st.markdown(outcomes_html, unsafe_allow_html=True)
+            st.markdown(components_html, unsafe_allow_html=True)
 
         with right:
             # Mission + Inbox preview side by side with the callouts


### PR DESCRIPTION
## Summary
- render the overview stage callouts using the defined components_html snippet
- resolve the NameError raised when loading the start-your-machine page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5210a6f10832195bc06169d8b2801