### PR TITLE
Adjust mission callout placement

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3210,6 +3210,10 @@ def render_overview_stage():
                     <h5>📥 Inbox interface</h5>
                     <p>A simulated inbox feeds emails into the system. Preview items, process a batch or review one by one, and optionally enable <strong>adaptiveness</strong> so your confirmations/corrections help the model improve.</p>
                 </div>
+                <div class="callout callout--info">
+                    <h5>🎯 Your mission</h5>
+                    <p>Keep unwanted email out while letting the important messages through.</p>
+                </div>
             </div>
             """
             st.markdown(components_html, unsafe_allow_html=True)
@@ -3218,20 +3222,6 @@ def render_overview_stage():
             st.markdown(
                 """
                 <div class="mission-preview-stack">
-                    <div class="mission-card">
-                        <div class="mission-header">
-                            <span class="mission-header-icon">🎯</span>
-                            <div>
-                                <h4>Your mission</h4>
-                                <p>Keep unwanted email out while letting the important messages through.</p>
-                            </div>
-                        </div>
-                        <ul class="mission-points">
-                            <li>Label examples so the model understands what <strong>spam</strong> and <strong>safe</strong> mean to you.</li>
-                            <li>Dial in the decision threshold to balance caution with convenience.</li>
-                            <li>Choose how much autonomy the system should have before you press <em>Start your machine</em>.</li>
-                        </ul>
-                    </div>
                     <div class="inbox-preview-card">
                         <div class="preview-header">
                             <span class="preview-header-icon">📥</span>


### PR DESCRIPTION
## Summary
- move the "Your mission" content into the overview callout grid so it shares the same styling as the other callouts
- remove the redundant mission card from the inbox preview column now that the mission message lives in the left callout group

## Testing
- streamlit run streamlit_app.py --server.port 8501 --server.headless true *(fails during shutdown due to environment atexit error)*

------
https://chatgpt.com/codex/tasks/task_e_68e5fdd1a2c48321acbb4f4b493fa5e8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Introduced a prominent “Your mission” info callout in the inbox overview, clarifying the goal of keeping unwanted email out while allowing important messages through.
  - Replaced the prior mission card with a cleaner callout format to reduce clutter and improve readability.
  - Improved visual grouping and emphasis in the overview stage while preserving existing inbox and preview layout and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->