### PR TITLE
Fix undefined stage navigation callbacks in Streamlit app

### DIFF
--- a/demistifai/constants.py
+++ b/demistifai/constants.py
@@ -718,6 +718,41 @@ STAGE_TEMPLATE_CSS = """
 </style>
 """
 
+STAGE_TEMPLATE_CSS += """
+<style>
+.stage-navigation-info {
+    text-align: center;
+    padding: 1.2rem 1.5rem;
+    border-radius: 18px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: linear-gradient(150deg, rgba(255, 255, 255, 0.96), rgba(226, 232, 240, 0.88));
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+    color: #0f172a;
+}
+
+.stage-navigation-step {
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(15, 23, 42, 0.55);
+    margin-bottom: 0.35rem;
+}
+
+.stage-navigation-title {
+    font-size: 1.3rem;
+    font-weight: 700;
+    margin-bottom: 0.35rem;
+}
+
+.stage-navigation-description {
+    font-size: 0.95rem;
+    line-height: 1.6;
+    margin: 0;
+    color: rgba(15, 23, 42, 0.75);
+}
+</style>
+"""
+
 EMAIL_INBOX_TABLE_CSS = """
 <style>
 .email-inbox-wrapper {


### PR DESCRIPTION
## Summary
- add a reusable `set_active_stage` helper to synchronize session state and query parameters
- implement bottom-of-page stage navigation controls and associated styling

## Testing
- python -m compileall streamlit_app.py
- python -m compileall -f demistifai/constants.py

------
https://chatgpt.com/codex/tasks/task_e_68e6239ab8588321bb20116eae10bbe8