### PR TITLE
Fix missing _counts import in Streamlit app

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -80,6 +80,7 @@ from demistifai.modeling import (
     df_confusion,
     encode_texts,
     extract_urls,
+    _counts,
     features_matrix,
     get_domain_tld,
     get_encoder,


### PR DESCRIPTION
## Summary
- import the `_counts` helper into the Streamlit app so post-training summaries can compute class counts without errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e62837add883219725748403cebf8c