### PR TITLE
Import missing sklearn metric for evaluation stage

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -96,7 +96,7 @@ from demistifai.modeling import (
     verdict_label,
 )
 
-from sklearn.metrics import accuracy_score, confusion_matrix
+from sklearn.metrics import accuracy_score, confusion_matrix, precision_recall_fscore_support
 from sklearn.model_selection import train_test_split
 
 st.set_page_config(page_title="demistifAI", page_icon="📧", layout="wide")


### PR DESCRIPTION
## Summary
- import `precision_recall_fscore_support` from `sklearn.metrics`
- prevent evaluation stage NameError when computing per-class metrics

## Testing
- python -m compileall streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68e62aef19988321b0844b5e408d695c