### PR TITLE
Enhance EU AI Act quote callout styling

### DIFF
--- a/demistifai/constants.py
+++ b/demistifai/constants.py
@@ -218,6 +218,62 @@ APP_THEME_CSS = """
     margin: 0 auto;
 }
 
+.ai-quote-box {
+    position: relative;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 1rem;
+    padding: 1.25rem 1.4rem;
+    margin: 1.2rem 0;
+    border-radius: 18px;
+    border: 1px solid rgba(30, 64, 175, 0.18);
+    background: linear-gradient(145deg, rgba(30, 64, 175, 0.08), rgba(30, 64, 175, 0));
+    box-shadow: 0 18px 42px rgba(15, 23, 42, 0.12);
+    color: #0f172a;
+}
+
+.ai-quote-box::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    border: 1px solid rgba(59, 130, 246, 0.16);
+    pointer-events: none;
+}
+
+.ai-quote-box__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    border-radius: 14px;
+    background: rgba(30, 64, 175, 0.12);
+    font-size: 1.6rem;
+    line-height: 1;
+    color: #1d4ed8;
+}
+
+.ai-quote-box__content {
+    display: grid;
+    gap: 0.35rem;
+}
+
+.ai-quote-box__source {
+    font-weight: 600;
+    font-size: 0.95rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: rgba(30, 64, 175, 0.82);
+}
+
+.ai-quote-box__content p {
+    margin: 0;
+    font-size: 0.98rem;
+    line-height: 1.7;
+    color: rgba(15, 23, 42, 0.92);
+}
+
 [data-testid="column"] > div[data-testid="stVerticalBlock"] {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- add dedicated CSS rules so EU AI Act quote callouts render with a distinct layout, icon treatment, and typography

## Testing
- streamlit run streamlit_app.py --server.port=8501 --server.headless=true *(fails on optional ML dependencies when stopping the server)*

------
https://chatgpt.com/codex/tasks/task_e_68e632ba58ec8321ac686d2d5ed25d7a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced an AI Quote Box component with icon, content area, and source label to present quotes/citations in a structured layout.

* Style
  * Added visual styling for the quote box: grid layout, padding, borders, subtle gradient background, shadows, and theme-aware colors.
  * Refined typography and spacing for quote content and metadata to improve readability and visual hierarchy.
  * Ensured consistent appearance across the app for quote-related elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->