### PR TITLE
Fix facet chart height property for diagnostics

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2097,12 +2097,13 @@ def render_data_stage():
                                     alt.Tooltip("count()", title="Count"),
                                 ],
                             )
+                            .properties(height=220)
                         )
                         chart = (
                             base_chart
                             .facet(column=alt.Column("label:N", title=None))
                             .resolve_scale(y="independent")
-                            .properties(height=220, title=feature_label)
+                            .properties(title=feature_label)
                         )
                         st.altair_chart(chart, use_container_width=True)
 


### PR DESCRIPTION
## Summary
- set the chart height on the base Altair chart before faceting to satisfy the schema
- keep the facet chart configuration and title while avoiding invalid properties

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e674d3468c8321924246416fd17298